### PR TITLE
Fixed Issue #1 in main form (Win32_Product - Wmi Windows Installer Pr…

### DIFF
--- a/sydi-server.vbs
+++ b/sydi-server.vbs
@@ -244,6 +244,7 @@ Dim strStylesheet, strXSLFreeText
 
 ' Constants
 Const adVarChar = 200
+Const adVarWChar = 202
 Const MaxCharacters = 255
 
 '==========================================================
@@ -1026,7 +1027,7 @@ Function GatherWMIInformation()
 		ReportProgress " Gathering application information"
 		Set colItems = objWMIService.ExecQuery("Select Name, Vendor, Version, InstallDate from Win32_Product WHERE Name <> Null",,48)
 		Set objDbrProducts = CreateObject("ADOR.Recordset")
-		objDbrProducts.Fields.Append "ProductName", adVarChar, MaxCharacters
+		objDbrProducts.Fields.Append "ProductName", adVarWChar, MaxCharacters
 		objDbrProducts.Fields.Append "Vendor", adVarChar, MaxCharacters
 		objDbrProducts.Fields.Append "Version", adVarChar, MaxCharacters
 		objDbrProducts.Fields.Append "InstallDate", adVarChar, MaxCharacters


### PR DESCRIPTION
…ovider).

Changed data type for "ProductName" field on Line 1030 from adVarChar to adVarWChar.  This should prevent errors when an installed program has non-English characters in its name.